### PR TITLE
Fix prettier config for formats other than TS.

### DIFF
--- a/prettier.js
+++ b/prettier.js
@@ -1,10 +1,17 @@
 module.exports = {
-  "trailingComma":  "all",
-  "semi": true,
-  "singleQuote":  true,
-  "quoteProps": "consistent",
-  "bracketSpacing": true,
-  "arrowParens": "always",
-  "tabWidth":  2,
-  "parser": "typescript"
+  overrides: [
+    {
+      files: ["*.mts", "*.cts", "*.ts"],
+      options: {
+        trailingComma: "all",
+        semi: true,
+        singleQuote: true,
+        quoteProps: "consistent",
+        bracketSpacing: true,
+        arrowParens: "always",
+        tabWidth: 2,
+        parser: "typescript"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
## What change has been made in this PR

Use **override** instead of putting the **parser** option at the top level of the configuration to avoid disabling Prettier’s automatic file extension based parser inference.

See https://stackoverflow.com/a/68088956/8579025

## Use cases:

```js
// .lintstagedrc.js
module.exports = {
  '*.ts': ['prettier --write', 'eslint --fix'],
  '*.json': ['prettier --write'] // this will throw SyntaxError if using 'parser' option in prettier.js
};

```